### PR TITLE
Create flow to restrict record deletion in Bid room

### DIFF
--- a/force-app/flows/Bid related - prevent from deleting records
+++ b/force-app/flows/Bid related - prevent from deleting records
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <areMetricsLoggedToDataCloud>false</areMetricsLoggedToDataCloud>
+    <customErrors>
+        <description>Prevents users from deleting records.</description>
+        <name>Restrict_Record_Deletion</name>
+        <label>Restrict Record Deletion</label>
+        <locationX>0</locationX>
+        <locationY>0</locationY>
+        <customErrorMessages>
+            <errorMessage>Salesforce is in Read-Only mode. All updates should be performed in ServiceNow.</errorMessage>
+            <isFieldError>false</isFieldError>
+        </customErrorMessages>
+    </customErrors>
+    <description>Prevents users from deleting records.</description>
+    <environments>Default</environments>
+    <interviewLabel>Bid room delete - Prevent Record Deletion {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Bid_room_delete- Prevent Record Deletion</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <start>
+        <locationX>0</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Restrict_Record_Deletion</targetReference>
+        </connector> <filterFormula>NOT($Permission.Prevent_Record_Create_and_Update)</filterFormula>
+        <object>Bid_room_delete__c</object>
+        <recordTriggerType>Delete</recordTriggerType>
+        <triggerType>RecordBeforeDelete</triggerType>
+    </start>
+    <status>Active</status>
+</Flow>


### PR DESCRIPTION
This flow prevents users from deleting records in the Bid room by enforcing a read-only mode.

# Tips

-   TITTEL
    -   Tittelen blir automatisk generert for deg, så skriv din ønskede tittel UTEN `SPESP-123`, osv
-   BESRKIVELSE
    -   Beskrivelsen (denne boksen) blir automatisk overskrevet med Jira-beskrivelsen
-   CODE REVIEW
    -   Unngå Code Review Post? Lag PR som draft eller legg på label `disable-review-post`
-   SNAPSHOTS
    -   Validering uten Snapshots? Legg på label `disable-snapshot`
